### PR TITLE
Show users only their jobs and enable admin to specify annotators for…

### DIFF
--- a/cvat/apps/dashboard/static/dashboard/js/dashboard.js
+++ b/cvat/apps/dashboard/static/dashboard/js/dashboard.js
@@ -79,6 +79,8 @@ function buildDashboard() {
 
 function setupTaskCreator() {
     let dashboardCreateTaskButton = $('#dashboardCreateTaskButton');
+    let dashboardGotoAdminButton = $('#dashboardGotoAdminButton');
+    let dashboardLogoutButton = $('#dashboardLogoutButton');
     let createModal = $('#dashboardCreateModal');
     let nameInput = $('#dashboardNameInput');
     let labelsInput = $('#dashboardLabelsInput');
@@ -116,6 +118,14 @@ function setupTaskCreator() {
 
     dashboardCreateTaskButton.on('click', function() {
         $('#dashboardCreateModal').removeClass('hidden');
+    });
+
+    dashboardGotoAdminButton.on('click', function() {
+        window.location.href = '/admin'
+    });
+
+    dashboardLogoutButton.on('click', function() {
+        window.location.href = '/auth/logout'
     });
 
     nameInput.on('change', (e) => {name = e.target.value;});

--- a/cvat/apps/dashboard/static/dashboard/stylesheet.css
+++ b/cvat/apps/dashboard/static/dashboard/stylesheet.css
@@ -84,7 +84,7 @@
     background: #0b7fff;
 }
 
-#dashboardCreateTaskButton {
+#dashboardCreateTaskButton, dashboardGotoAdminButton, dashboardLogoutButton {
     font-size: 2em;
 }
 

--- a/cvat/apps/dashboard/static/dashboard/stylesheet.css
+++ b/cvat/apps/dashboard/static/dashboard/stylesheet.css
@@ -84,7 +84,7 @@
     background: #0b7fff;
 }
 
-#dashboardCreateTaskButton, dashboardGotoAdminButton, dashboardLogoutButton {
+#dashboardCreateTaskButton {
     font-size: 2em;
 }
 

--- a/cvat/apps/dashboard/templates/dashboard/dashboard.html
+++ b/cvat/apps/dashboard/templates/dashboard/dashboard.html
@@ -40,7 +40,12 @@
         <center>
             <table style="width: 65%;">
                 <tr>
-                    <td><button id="dashboardCreateTaskButton" class="regular h1"> Create New Task </button></td>
+                    {% if user.is_superuser%}
+                        <td><button id="dashboardCreateTaskButton" class="regular h1"> Create New Task </button></td>
+                        <td><button id="dashboardGotoAdminButton" class="regular h1"> Admin portal </button></td>
+                    {% endif %}
+
+                    <td><button id="dashboardLogoutButton" class="regular h1"> Logout </button></td>
                     <td>
                         <div style="width: 300px; float: right;">
                             <input type="text" id="dashboardSearchInput" class="regular h1" placeholder="Search.." name="search">

--- a/cvat/apps/engine/admin.py
+++ b/cvat/apps/engine/admin.py
@@ -1,3 +1,9 @@
 from django.contrib import admin
+from cvat.apps.engine.models import Job
 
-# Register your models here.
+@admin.register(Job)
+class JobAdmin(admin.ModelAdmin):
+    list_display = ['get_task_name', 'get_id', 'annotator']
+    list_filter = ['annotator']
+    search_fields = ['segment__task__name']
+    fields = ['annotator']

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -53,11 +53,7 @@ class Task(models.Model):
         return self.path
 
     def get_user_segments(self, user):
-        segments = []
-        for segment in self.segment_set.all():
-            if segment.check_user_access(user):
-                segments.append(segment)
-        return segments
+        return [s for s in self.segment_set.all() if s.check_user_access(user)]
 
     def __str__(self):
         return self.name

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -160,7 +160,7 @@ CACHEOPS_DEGRADE_ON_FAILURE = True
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'Europe/Moscow'
+TIME_ZONE = 'America/Chicago'
 
 USE_I18N = True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         no_proxy:
         TF_ANNOTATION: "no"
         USER: "django"
-        DJANGO_CONFIGURATION: "production"
+        DJANGO_CONFIGURATION: "staging"
         WITH_TESTS: "no"
     environment:
       DJANGO_MODWSGI_EXTRA_ARGS: ""


### PR DESCRIPTION
**Things changed:**

- Added Jobs section to Admin page to enable selection of job annotators

- User would only see the Jobs that are assigned to them except for the admin can see all the jobs

- Edited the docker-compose file to enable debugging (setting config. to staging)

- Modified README file

- Modified gitignore file to remove pycharm config. files

- Changed timezone to 'America/Chicago'