### PR TITLE
- Resized width of css strokes to 1

### DIFF
--- a/cvat/apps/engine/static/engine/js/trackModel.js
+++ b/cvat/apps/engine/static/engine/js/trackModel.js
@@ -32,7 +32,7 @@ class TrackModel extends Listener {
         this._activeKeypoint = null;
         this._merge = false;
         this._hidden = false;
-        this._hiddenLabel = true;
+        this._hiddenLabel = false;
         this._selected = false;
         this._activeAAMTrack = false;
         this._activeAttribute = null;

--- a/cvat/apps/engine/static/engine/js/trackView.js
+++ b/cvat/apps/engine/static/engine/js/trackView.js
@@ -287,6 +287,7 @@ class TrackView {
         }
         */
         if (!(state.model.hiddenLabel || state.model.outside || state.model.hidden)) {
+            this.updateAndViewText(state);
             this._text.appendTo(this._framecontent);
         }
         else {
@@ -357,7 +358,6 @@ class TrackView {
         let keyFrame = state.position.keyFrame === true;
 
         this._ui.keyFrame(keyFrame);
-
 
         let outsided = state.position.outsided;
         /*
@@ -433,7 +433,7 @@ class TrackView {
             });
 
             //text transformation
-            let xmargin = -6;
+            let xmargin = -12;
             let ymargin = 5;
 
             let cxpos = +shape.attr('cx') + xmargin;


### PR DESCRIPTION
- Worker and activity labels are set as visible by default
- Bugfix: activity label changes are displayed immediately