### PR TITLE
UI improvements and fixes

### DIFF
--- a/cvat/apps/engine/static/engine/base.css
+++ b/cvat/apps/engine/static/engine/base.css
@@ -1,10 +1,16 @@
 html {
     background-color: #FFFFFF;
     margin: 0px auto;
+    height : 100%;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+}
+
+body{
+    margin: 0px auto;
+    height : 100%;
 }
 
 @font-face {

--- a/cvat/apps/engine/static/engine/js/annotationUI.js
+++ b/cvat/apps/engine/static/engine/js/annotationUI.js
@@ -276,11 +276,11 @@ function setupMenu(job, collectionModel, collectionController, annotationParser)
         fillStat(statistic, job); */
         annotationMenu.removeClass('hidden');
         clearTimeout(visibleTimer);
-        visibleTimer = setTimeout(hideMenu, 500);
+        visibleTimer = setTimeout(hideMenu, 1500);
     });
 
     annotationMenu.on('mouseout', function() {
-        visibleTimer = setTimeout(hideMenu, 500);
+        visibleTimer = setTimeout(hideMenu, 1500);
     });
 
     annotationMenu.on('mouseover', function() {

--- a/cvat/apps/engine/static/engine/js/base.js
+++ b/cvat/apps/engine/static/engine/js/base.js
@@ -157,7 +157,8 @@ $.ajaxSetup({
 
 $(document).ready(function(){
     $('body').css({
-        width: window.screen.width * 0.97 + 'px',
-        height: window.screen.height * 0.97 + 'px'
+        //width: window.screen.width * 0.97 + 'px',
+        height: '100%',
+        margin :'0px'//window.screen.height * 0.97 + 'px'
     });
 });


### PR DESCRIPTION
- When hovering over keypoint circle, keypoint name appears until
  no longer highlighted (when mouse moves off)
- When hovering over occluded button, keypoint circle radius
  doubled (TODO: should also be highlighted)
- Minor increase in amount of time Menu stays open
- Annotation tool page fits slightly better in window (TODO: worker
  label slightly truncated by top of window, might need to further
  zoom out or decrease the window size)