### PR TITLE
Taskname-> annotator, new users annotators and staff by default

### DIFF
--- a/cvat/apps/authentication/settings/auth_simple.py
+++ b/cvat/apps/authentication/settings/auth_simple.py
@@ -1,2 +1,2 @@
 # Specify groups that new users will have
-AUTH_SIMPLE_DEFAULT_GROUPS = []
+AUTH_SIMPLE_DEFAULT_GROUPS = ['annotator']

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -96,10 +96,10 @@ class Job(models.Model):
     get_id.admin_order_field = 'id'
 
     def get_deltatime(self):
-        if timezone.now() - self.updated_date < timezone.timedelta(minutes=2):
-            return 'False'
-        else:
-            return 'True'
+        #if timezone.now() - self.updated_date < timezone.timedelta(minutes=2):
+        #    return 'False'
+        #else:
+        return 'True'
 
 
     # TODO: add sub-issue number for the task

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -39,7 +39,7 @@ def create_empty(params):
     db_task.bug_tracker = params['bug_tracker_link']
     db_task.path = ""
     db_task.size = 0
-    db_task.owner = params['owner']
+    db_task.owner = params['owner']#models.User.objects.get(username=params['owner'])
     db_task.save()
     task_path = os.path.join(settings.DATA_ROOT, str(db_task.id))
     db_task.set_task_dirname(task_path)
@@ -320,7 +320,7 @@ def _parse_db_labels(db_labels):
 @transaction.atomic
 def _create_thread(tid, params):
     # TODO: Improve a function logic. Need filter paths from a share storage before their copy to the server
-    db_task = db_task = models.Task.objects.select_for_update().get(pk=tid)
+    db_task = models.Task.objects.select_for_update().get(pk=tid)
 
     upload_dir = db_task.get_upload_dirname()
     output_dir = db_task.get_data_dirname()
@@ -372,6 +372,9 @@ def _create_thread(tid, params):
                 if not os.path.exists(dirname):
                     os.makedirs(dirname)
                 shutil.copyfile(image_orig_path, image_dest_path)
+
+
+        '''
         else:
             extensions = ['.jpg', '.png', '.bmp', '.jpeg']
             filenames = []
@@ -408,6 +411,7 @@ def _create_thread(tid, params):
                     os.makedirs(dirname)
                 os.symlink(image_orig_path, image_dest_path)
             log_file.write("Formatted {0} images\n".format(len(filenames)))
+        '''
 
         default_segment_length = sys.maxsize    # greather then any task size. Default split by segments disabled.
         segment_length = int(params.get('segment_size', default_segment_length))
@@ -435,6 +439,7 @@ def _create_thread(tid, params):
 
             db_job = models.Job()
             db_job.segment = db_segment
+            db_job.annotator = models.User.objects.get(username=params['annotator'])
             db_job.save()
 
         labels = params['labels']


### PR DESCRIPTION
- Quick hack to facilitate mass task creation and assignment to users. When a new task is created, entry in the "name" field should be the username of the annotator it will be assigned to. Also, multiple video tasks can be created at the same time (support removed for folders of images) just by selecting several via "select files".
- When creating users via the admin, they are now set to staff status and belong to the annotator group by default.